### PR TITLE
Add auto-update feature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+.stylelintrc.yml export-ignore
+.travis.yml export-ignore
+composer.json export-ignore
+CONTRIBUTING.md export-ignore
+package.json export-ignore
+package-lock.json export-ignore
+phpcs.ruleset.xml export-ignore
+/bin export-ignore
+/tests export-ignore
+/src export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Update WSUWP_Help_Docs_Updater class documentation.
 * Clean up debugging and phpcs issues in WSUWP_Help_Docs_Updater class.
 * The `update_pluign_{slug}` transient now not only stores the GitHub response of a successful request, but also an error placeholder (for 60 minutes) on a failed request. This guarantees we only ping the GitHub API at most once an hour, helping to prevent spamming the service if something breaks on our end.
 * Fine-tuned error handling in `WSUWP_Help_Docs_Updater->get_repository_details()` to warn of failed requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Changelog formatting (http://semver.org/):
 
 ## 0.4.0 (unreleased)
 
+### Changed
+
+* Load the updater class in the main plugin file and setup class and define the base credentials in the main plugin file.
+
 ### Added
 
 * Updater class to check GitHub repo for newer plugin version and install it if found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Changelog formatting (http://semver.org/):
 
 ### Added
 
+* WSUWP_Help_Docs_Updater method to ensure updated plugin files are in the correct place and the plugin reactivated if it was already active.
 * WSUWP_Help_Docs_Updater method to add additional header fields to the `get_plugin_data` function call.
 * WSUWP_Help_Docs_Updater method to handle displaying errors when the connection fails.
 * Method to add a "view details" link to the row meta on the plugins admin screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
+## 0.4.0 (unreleased)
+
+### Added
+
+* Updater class to check GitHub repo for newer plugin version and install it if found.
+
 ## 0.3.1 (2018-09-18)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Use plugin metadata for the required version fields when fetching plugin info in the WSUWP_Help_Docs_Updater class.
 * Move WP required version, tested version, and PHP version meta to plugin head matter.
 * Update WSUWP_Help_Docs_Updater class documentation.
 * Clean up debugging and phpcs issues in WSUWP_Help_Docs_Updater class.
@@ -38,6 +39,7 @@ Changelog formatting (http://semver.org/):
 
 ### Added
 
+* WSUWP_Help_Docs_Updater method to add additional header fields to the `get_plugin_data` function call.
 * WSUWP_Help_Docs_Updater method to handle displaying errors when the connection fails.
 * Method to add a "view details" link to the row meta on the plugins admin screen.
 * Dedicated `$slug` property in `WSUWP_Help_Docs_Updater` class to fetch slug separate from basename.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.4.0 (unreleased)
+## 0.4.1 (unreleased)
+
+### Fixed
+
+* Corrected plugin repo username.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
-## 0.4.1 (unreleased)
+## 0.4.1 (2018-09-27)
 
 ### Fixed
 
@@ -40,6 +40,7 @@ Changelog formatting (http://semver.org/):
 
 ### Added
 
+* A `.gitattributes` file to ignore development files on GitHub's zip export.
 * WSUWP_Help_Docs_Updater method to ensure updated plugin files are in the correct place and the plugin reactivated if it was already active.
 * WSUWP_Help_Docs_Updater method to add additional header fields to the `get_plugin_data` function call.
 * WSUWP_Help_Docs_Updater method to handle displaying errors when the connection fails.
@@ -48,6 +49,10 @@ Changelog formatting (http://semver.org/):
 * Method for retrieving plugin details from the GitHub API and displaying on the plugins admin screen.
 * Method for checking and updating the WP `update_plugins` transient with information from the GitHub API.
 * Updater class to check GitHub repo for newer plugin version and install it if found.
+
+### Removed
+
+* The `deploy` npm script in favor of GitHub exports.
 
 ## 0.3.1 (2018-09-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # WSUWP Help Docs Changelog
 
-Authors: Adam Turner, Washington State University
-
+Authors: Adam Turner, Washington State University\
 URI: https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs
 
 <!--
@@ -27,7 +26,7 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
-* Include WordPress-ish head matter in `README.md`.
+* Move WP required version, tested version, and PHP version meta to plugin head matter.
 * Update WSUWP_Help_Docs_Updater class documentation.
 * Clean up debugging and phpcs issues in WSUWP_Help_Docs_Updater class.
 * The `update_pluign_{slug}` transient now not only stores the GitHub response of a successful request, but also an error placeholder (for 60 minutes) on a failed request. This guarantees we only ping the GitHub API at most once an hour, helping to prevent spamming the service if something breaks on our end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,17 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Clean up debugging and phpcs issues in WSUWP_Help_Docs_Updater class.
+* The `update_pluign_{slug}` transient now not only stores the GitHub response of a successful request, but also an error placeholder (for 60 minutes) on a failed request. This guarantees we only ping the GitHub API at most once an hour, helping to prevent spamming the service if something breaks on our end.
+* Fine-tuned error handling in `WSUWP_Help_Docs_Updater->get_repository_details()` to warn of failed requests.
+* We only need the latest release from GitHub, so specify `/latest` in the request URI instead of requesting all releases (which means we also don't need the `is_array` > `current()` conditional on the API response).
 * Replace `current( explode(` method to build the plugin slug with `$slug` class property.
 * Use `transient_update_plugins` hook instead of `pre_set_site_transient_update_plugins`.
 * Load the updater class in the main plugin file and setup class and define the base credentials in the main plugin file.
 
 ### Added
 
+* WSUWP_Help_Docs_Updater method to handle displaying errors when the connection fails.
 * Method to add a "view details" link to the row meta on the plugins admin screen.
 * Dedicated `$slug` property in `WSUWP_Help_Docs_Updater` class to fetch slug separate from basename.
 * Method for retrieving plugin details from the GitHub API and displaying on the plugins admin screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Use `transient_update_plugins` hook instead of `pre_set_site_transient_update_plugins`.
 * Load the updater class in the main plugin file and setup class and define the base credentials in the main plugin file.
 
 ### Added
 
+* Method for retrieving plugin details from the GitHub API and displaying on the plugins admin screen.
+* Method for checking and updating the WP `update_plugins` transient with information from the GitHub API.
 * Updater class to check GitHub repo for newer plugin version and install it if found.
 
 ## 0.3.1 (2018-09-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,19 @@ Changelog formatting (http://semver.org/):
 
 ### Fixed
 
+* Remove the "v" from the GitHub version number for more reliable version comparison.
 * Corrected plugin repo username.
 
 ### Changed
 
+* Replace `current( explode(` method to build the plugin slug with `$slug` class property.
 * Use `transient_update_plugins` hook instead of `pre_set_site_transient_update_plugins`.
 * Load the updater class in the main plugin file and setup class and define the base credentials in the main plugin file.
 
 ### Added
 
+* Method to add a "view details" link to the row meta on the plugins admin screen.
+* Dedicated `$slug` property in `WSUWP_Help_Docs_Updater` class to fetch slug separate from basename.
 * Method for retrieving plugin details from the GitHub API and displaying on the plugins admin screen.
 * Method for checking and updating the WP `update_plugins` transient with information from the GitHub API.
 * Updater class to check GitHub repo for newer plugin version and install it if found.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # WSUWP Help Docs Changelog
 
-Author: Adam Turner
-Author: Washington State University
+Authors: Adam Turner, Washington State University
+
 URI: https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs
 
 <!--
@@ -27,6 +27,7 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Include WordPress-ish head matter in `README.md`.
 * Update WSUWP_Help_Docs_Updater class documentation.
 * Clean up debugging and phpcs issues in WSUWP_Help_Docs_Updater class.
 * The `update_pluign_{slug}` transient now not only stores the GitHub response of a successful request, but also an error placeholder (for 60 minutes) on a failed request. This guarantees we only ping the GitHub API at most once an hour, helping to prevent spamming the service if something breaks on our end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog formatting (http://semver.org/):
 
 ### Changed
 
+* Format WSUWP_Help_Docs_Updater changelog output with `the_content` filter.
 * Use plugin metadata for the required version fields when fetching plugin info in the WSUWP_Help_Docs_Updater class.
 * Move WP required version, tested version, and PHP version meta to plugin head matter.
 * Update WSUWP_Help_Docs_Updater class documentation.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # WSUWP Help Docs
 
+Contributors: admturner, washingtonstateuniversity
+Requires at least: 4.0
+Tested up to: 4.9
+Stable tag: 0.4.1
+Requires PHP: 5.3
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+## Description
+
 This plugin creates a Help custom post type. The Help posts cannot be viewed or queried from the front end of the site. They're intended to provide help, guidance, and instructions for logged in site users. The plugin generates two new areas in the WP Admin area:
 
 1. A subpage under the Tools section where registered site users with Editor capabilities and up can manage Help posts.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # WSUWP Help Docs
 
-Contributors: admturner, washingtonstateuniversity
-Requires at least: 4.0
-Tested up to: 4.9
-Stable tag: 0.4.1
-Requires PHP: 5.3
-License: GPLv2 or later
+Contributors: admturner, washingtonstateuniversity\
+Requires at least: 4.0\
+Tested up to: 4.9\
+Stable tag: 0.4.1\
+Requires PHP: 5.3\
+License: GPLv2 or later\
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # WSUWP Help Docs
 
-Contributors: admturner, washingtonstateuniversity\
-Requires at least: 4.0\
-Tested up to: 4.9\
-Stable tag: 0.4.1\
-Requires PHP: 5.3\
-License: GPLv2 or later\
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
-
 ## Description
 
 This plugin creates a Help custom post type. The Help posts cannot be viewed or queried from the front end of the site. They're intended to provide help, guidance, and instructions for logged in site users. The plugin generates two new areas in the WP Admin area:

--- a/includes/class-help-docs-setup.php
+++ b/includes/class-help-docs-setup.php
@@ -78,6 +78,7 @@ class WSUWP_Help_Docs {
 	 */
 	private function includes() {
 		require __DIR__ . '/class-page-list-walker.php';
+		require __DIR__ . '/class-help-docs-updater.php';
 	}
 
 	/**
@@ -88,6 +89,7 @@ class WSUWP_Help_Docs {
 	 * @access private
 	 */
 	private function setup_hooks() {
+		add_action( 'init', 'load_wsuwp_help_updater' );
 		add_action( 'init', array( $this, 'register' ), 10 );
 		add_action( 'after_setup_theme', array( $this, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'admin_menu', array( $this, 'help_menu' ) );

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -96,11 +96,11 @@ class WSUWP_Help_Docs_Updater {
 	/**
 	 * Instantiates WSUWP Help singleton.
 	 *
-	 * @since 0.1.0
+	 * @since 0.4.0
 	 *
-	 * @return object The WSUWP Help object
+	 * @return object The WSUWP_Help_Docs_Updater object
 	 */
-	public static function get_instance( $file = '' ) {
+	public static function get_instance( $file ) {
 		static $instance = null;
 
 		// Only set up and activate the plugin if it hasn't already been done.
@@ -116,7 +116,7 @@ class WSUWP_Help_Docs_Updater {
 	/**
 	 * An empty constructor to prevent WSUWP Help being loaded more than once.
 	 *
-	 * @since 0.1.0
+	 * @since 0.4.0
 	 */
 	public function __construct() {
 		/* Nothing doing. */
@@ -369,6 +369,7 @@ class WSUWP_Help_Docs_Updater {
 		}
 
 		if ( $this->github_response && 'request-error-wait' !== $this->github_response ) {
+			/* translators: 1: the plugin version number, 2: the HTML formatted release message from GitHub */
 			$changelog = sprintf( __( '<strong>Version %1$s Changes</strong>%2$s', 'wsuwp-help-docs' ),
 				$this->github_response['tag_name'],
 				apply_filters( 'the_content', $this->github_response['body'] )
@@ -401,7 +402,7 @@ class WSUWP_Help_Docs_Updater {
 	/**
 	 * Adds a "view details" link to the plugin row meta.
 	 *
-	 * Callback function for the `plugin_row_meta` filter hook. This funciton
+	 * Callback function for the `plugin_row_meta` filter hook. This function
 	 * modifies the plugin_meta variable to add a "View Details" link like the
 	 * one for plugins in the WP plugin repository. The link will generate
 	 * the modal ({@uses install_plugin_information()}) using `plugins_api()`,

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -383,7 +383,7 @@ class WSUWP_Help_Docs_Updater {
 			$result->short_description = $this->plugin_meta['Description'];
 			$result->sections          = array(
 				'description' => $this->plugin_meta['Description'],
-				'changelog'     => $this->github_response['body'],
+				'changelog'   => $this->github_response['body'],
 			);
 			$result->download_link     = $this->github_response['zipball_url'];
 
@@ -428,13 +428,30 @@ class WSUWP_Help_Docs_Updater {
 	}
 
 	/**
-	 * try adding custom plugin headers
+	 * Adds custom headers for WordPress and PHP version requirements.
+	 *
+	 * Callback function for the `extra_{$context}_headers` WP Filter hook,
+	 * where here `$context` is `plugin`. This hook fires in `get_file_data()`,
+	 * called in this context by `get_plugin_data()`. The `get_plugin_data`
+	 * function passes the `plugin` context, allowing us to add some custom
+	 * headers to the plugin data parser. The values passed here must match
+	 * the head matter in the main plugin file, and must be passed as-is to the
+	 * `WSUWP_Help_Docs_Updater->display_plugin_details()` results object.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/get_file_data/
+	 * @link https://developer.wordpress.org/reference/functions/get_plugin_data/
+	 * @link https://codex.wordpress.org/File_Header
+	 *
+	 * @since 0.4.1
+	 *
+	 * @param array $extra_headers List of headers, in the format array('HeaderKey' => 'Header Name').
+	 * @return array Array of file headers to add to the default headers array.
 	 */
 	public function add_plugin_headers( $extra_headers ) {
 		$extra_headers = array(
-			'requires_at_least' => 'Requires at least',
-			'tested_up_to'      => 'Tested up to',
-			'requires_php'      => 'Requires PHP',
+			'RequiresAtLeast' => 'Requires at least',
+			'TestedUpTo'      => 'Tested up to',
+			'RequiresPHP'     => 'Requires PHP',
 		);
 
 		return $extra_headers;

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -136,6 +136,7 @@ class WSUWP_Help_Docs_Updater {
 		add_filter( 'plugins_api', array( $this, 'display_plugin_details' ), 10, 3 );
 		add_filter( 'plugin_row_meta', array( $this, 'update_plugin_row_meta' ), 10, 2 );
 		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+		add_filter( 'extra_plugin_headers', array( $this, 'add_plugin_headers' ), 10, 1 );
 	}
 
 	/**
@@ -372,11 +373,9 @@ class WSUWP_Help_Docs_Updater {
 			$result->name              = $this->plugin_meta['Name'];
 			$result->slug              = $this->slug;
 			$result->version           = str_replace( 'v', '', $this->github_response['tag_name'] );
-			$result->requires          = '3.3';
-			$result->tested            = '4.9';
-			$result->rating            = '100';
-			$result->num_ratings       = '1';
-			$result->downloaded        = '1';
+			$result->requires          = $this->plugin_meta['Requires at least'];
+			$result->tested            = $this->plugin_meta['Tested up to'];
+			$result->requires_php      = $this->plugin_meta['Requires PHP'];
 			$result->author            = $this->plugin_meta['AuthorName'];
 			$result->author_profile    = $this->plugin_meta['AuthorURI'];
 			$result->last_updated      = $this->github_response['published_at'];
@@ -384,7 +383,7 @@ class WSUWP_Help_Docs_Updater {
 			$result->short_description = $this->plugin_meta['Description'];
 			$result->sections          = array(
 				'description' => $this->plugin_meta['Description'],
-				'updates'     => $this->github_response['body'],
+				'changelog'     => $this->github_response['body'],
 			);
 			$result->download_link     = $this->github_response['zipball_url'];
 
@@ -426,6 +425,19 @@ class WSUWP_Help_Docs_Updater {
 		}
 
 		return $plugin_meta;
+	}
+
+	/**
+	 * try adding custom plugin headers
+	 */
+	public function add_plugin_headers( $extra_headers ) {
+		$extra_headers = array(
+			'requires_at_least' => 'Requires at least',
+			'tested_up_to'      => 'Tested up to',
+			'requires_php'      => 'Requires PHP',
+		);
+
+		return $extra_headers;
 	}
 
 	/**

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -369,6 +369,11 @@ class WSUWP_Help_Docs_Updater {
 		}
 
 		if ( $this->github_response && 'request-error-wait' !== $this->github_response ) {
+			$changelog = sprintf( __( '<strong>Version %1$s Changes</strong>%2$s', 'wsuwp-help-docs' ),
+				$this->github_response['tag_name'],
+				apply_filters( 'the_content', $this->github_response['body'] )
+			);
+
 			$result                    = new stdClass();
 			$result->name              = $this->plugin_meta['Name'];
 			$result->slug              = $this->slug;
@@ -383,7 +388,7 @@ class WSUWP_Help_Docs_Updater {
 			$result->short_description = $this->plugin_meta['Description'];
 			$result->sections          = array(
 				'description' => $this->plugin_meta['Description'],
-				'changelog'   => $this->github_response['body'],
+				'changelog'   => $changelog,
 			);
 			$result->download_link     = $this->github_response['zipball_url'];
 

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * WSUWP Help Docs Updater: WSUWP_Help_Docs_Updater class
+ *
+ * @package WSUWP_Help_Docs
+ * @since 0.4.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * The WSUWP Help Docs updater class.
+ *
+ * Checks the WSUWP Help Docs GitHub repository latest release version against
+ * the current installed version to alert administrators of newer versions.
+ * Allows administrators to update the plugin automatically from the plugins
+ * screen.
+ *
+ * @since 0.4.0
+ */
+class WSUWP_Help_Docs_Updater {
+	/**
+	 * The main plugin file path.
+	 *
+	 * @since 0.4.0
+	 * @var string
+	 */
+	private $file;
+
+	/**
+	 * The plugin metadata.
+	 *
+	 * @since 0.4.0
+	 * @var array
+	 */
+	private $plugin_meta;
+
+	/**
+	 * Path to the plugin file or directory.
+	 *
+	 * @since 0.4.0
+	 * @var string
+	 */
+	private $basename;
+
+	/**
+	 * Whether the plugin is activated.
+	 *
+	 * @since 0.4.0
+	 * @var bool
+	 */
+	private $active;
+
+	/**
+	 * The username for the plugin GitHub repository.
+	 *
+	 * @since 0.4.0
+	 * @var string
+	 */
+	private $username;
+
+	/**
+	 * The name of the plugin GitHub repository.
+	 *
+	 * @since 0.4.0
+	 * @var string
+	 */
+	private $repository;
+
+	/**
+	 * The API authorization token for private GitHub repositories.
+	 *
+	 * @since 0.4.0
+	 * @var string
+	 */
+	private $auth_token;
+
+	/**
+	 * The GitHub API response data.
+	 *
+	 * @since 0.4.0
+	 * @var array
+	 */
+	private $github_response;
+
+
+	/**
+	 * Instantiates WSUWP Help singleton.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @return object The WSUWP Help object
+	 */
+	public static function get_instance( $file = '' ) {
+		static $instance = null;
+
+		// Only set up and activate the plugin if it hasn't already been done.
+		if ( null === $instance ) {
+			$instance = new WSUWP_Help_Docs_Updater();
+			$instance->file = $file;
+			$instance->setup_hooks();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * An empty constructor to prevent WSUWP Help being loaded more than once.
+	 *
+	 * @since 0.1.0
+	 */
+	public function __construct() {
+		/* Nothing doing. */
+	}
+
+	/**
+	 * Loads the WP API actions and hooks.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @access private
+	 */
+	private function setup_hooks() {
+		add_action( 'admin_init', array( $this, 'set_properties' ) );
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
+		add_filter( 'plugins_api', array( $this, 'display_plugin_details' ), 10, 3 );
+		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
+	}
+
+	/**
+	 * Defines the plugin GitHub credentials.
+	 *
+	 * @since 0.4.0
+	 */
+	public function set_github_credentials( $props ) {
+		$defaults = array(
+			'username'   => $this->username,
+			'repository' => $this->repository,
+			'auth_token' => $this->auth_token,
+		);
+
+		$props = wp_parse_args( $props, $defaults );
+
+		$this->username   = $props['username'];
+		$this->repository = $props['repository'];
+		$this->auth_token = $props['auth_token'];
+	}
+
+	/**
+	 * Defines the plugin properties to pass to the GitHub API.
+	 *
+	 * @since 0.4.0
+	 */
+	public function set_properties() {
+		if ( empty( $this->file ) ) {
+			return false;
+		}
+
+		$this->plugin   = get_plugin_data( $this->file );
+		$this->basename = plugin_basename( $this->file );
+		$this->active   = is_plugin_active( $this->basename );
+	}
+
+	/**
+	 * Gets the plugin repository info from the GitHub API.
+	 *
+	 * @link
+	 *
+	 * @since 0.4.0
+	 */
+
+	/**
+	 * update the transient etc
+	 */
+	public function modify_transient( $transient ) {
+		// check and update the transient
+	}
+
+	/**
+	 * display the plugin details modal window
+	 */
+	public function display_plugin_details( $result, $action, $args ) {
+		// retrieve and display the plugin release info as the details window.
+	}
+
+	/**
+	 * actions for after installation
+	 */
+	public function after_install( $response, $hook_extra, $result ) {
+		// steps to take after installation
+	}
+}

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -142,6 +142,13 @@ class WSUWP_Help_Docs_Updater {
 	 * Sets the plugin GitHub credentials.
 	 *
 	 * @since 0.4.0
+	 *
+	 * @param $props {
+	 *     @type string $username   Required. A valid GitHub username for the repository.
+	 *     @type string $repository Required. The GitHub repository to watch for updates.
+	 *     @type string $auth_token Optional. A GitHub authorization token.
+	 * }
+	 * @return void
 	 */
 	public function set_github_credentials( $props ) {
 		$defaults = array(
@@ -158,7 +165,7 @@ class WSUWP_Help_Docs_Updater {
 	}
 
 	/**
-	 * Sets the plugin properties to pass to the GitHub API.
+	 * Sets the plugin properties.
 	 *
 	 * @since 0.4.0
 	 */
@@ -262,7 +269,7 @@ class WSUWP_Help_Docs_Updater {
 	}
 
 	/**
-	 * Checks for a newer version and updates the transient if so.
+	 * Checks for a newer version and updates the transient accordingly.
 	 *
 	 * Callback function for the WP API `{site_}transient_update_plugins`
 	 * filter hooks. Checks the version number from the installed version of the
@@ -273,7 +280,7 @@ class WSUWP_Help_Docs_Updater {
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param object $transient Required. The WP update_plugins transient.
+	 * @param object $transient Required. The WP `update_plugins` transient.
 	 * @return object $transient The same or modified transient object.
 	 */
 	public function push_transient_update( $transient ) {
@@ -321,9 +328,18 @@ class WSUWP_Help_Docs_Updater {
 	}
 
 	/**
-	 * display the plugin details modal window
+	 * Displays the plugin details modal.
 	 *
-	 * retrieve and display the plugin release info as the details window.
+	 * The callback function for the 'plugins_api' WP API filter hook. This
+	 * retrieves and displays the plugin release info along with the plugin
+	 * meta information in the WordPress details modal window.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param object $result Required. The result object is required for the `plugin_information` action.
+	 * @param string $action The type of information being requested from the Plugin Installation API.
+	 * @param object $args The Plugin API arguments.
+	 * @return object|false The result object with the plugin details added or false.
 	 */
 	public function display_plugin_details( $result, $action, $args ) {
 		// Do nothing if this isn't a request for information.

--- a/includes/class-help-docs-updater.php
+++ b/includes/class-help-docs-updater.php
@@ -85,7 +85,6 @@ class WSUWP_Help_Docs_Updater {
 	 */
 	private $github_response;
 
-
 	/**
 	 * Instantiates WSUWP Help singleton.
 	 *
@@ -98,7 +97,7 @@ class WSUWP_Help_Docs_Updater {
 
 		// Only set up and activate the plugin if it hasn't already been done.
 		if ( null === $instance ) {
-			$instance = new WSUWP_Help_Docs_Updater();
+			$instance       = new WSUWP_Help_Docs_Updater();
 			$instance->file = $file;
 			$instance->setup_hooks();
 		}
@@ -124,13 +123,14 @@ class WSUWP_Help_Docs_Updater {
 	 */
 	private function setup_hooks() {
 		add_action( 'admin_init', array( $this, 'set_properties' ) );
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'modify_transient' ), 10, 1 );
+		add_filter( 'transient_update_plugins', array( $this, 'push_transient_update' ), 10, 1 );
+		add_filter( 'site_transient_update_plugins', array( $this, 'push_transient_update' ), 10, 1 );
 		add_filter( 'plugins_api', array( $this, 'display_plugin_details' ), 10, 3 );
 		add_filter( 'upgrader_post_install', array( $this, 'after_install' ), 10, 3 );
 	}
 
 	/**
-	 * Defines the plugin GitHub credentials.
+	 * Sets the plugin GitHub credentials.
 	 *
 	 * @since 0.4.0
 	 */
@@ -149,7 +149,7 @@ class WSUWP_Help_Docs_Updater {
 	}
 
 	/**
-	 * Defines the plugin properties to pass to the GitHub API.
+	 * Sets the plugin properties to pass to the GitHub API.
 	 *
 	 * @since 0.4.0
 	 */
@@ -158,31 +158,196 @@ class WSUWP_Help_Docs_Updater {
 			return false;
 		}
 
-		$this->plugin   = get_plugin_data( $this->file );
-		$this->basename = plugin_basename( $this->file );
-		$this->active   = is_plugin_active( $this->basename );
+		$this->plugin_meta = get_plugin_data( $this->file );
+		$this->basename    = plugin_basename( $this->file );
+		$this->active      = is_plugin_active( $this->basename );
 	}
 
 	/**
 	 * Gets the plugin repository info from the GitHub API.
 	 *
-	 * @link
+	 * Connects to the plugin repository using the GitHub API (v3) to retrieve
+	 * repo data in JSON format and parse it.
+	 *
+	 * @link https://developer.github.com/v3/
 	 *
 	 * @since 0.4.0
+	 *
+	 * @return array Array of parsed JSON GitHub repository details.
 	 */
+	private function get_repository_details() {
+		// If a response already exists, return it.
+		if ( ! empty( $this->github_response ) ) {
+			return $this->github_response;
+		}
+
+		// Build the GitHub API request URI.
+		$request_uri = sprintf( 'https://api.github.com/repos/%1$s/%2$s/releases',
+			$this->username,
+			$this->repository
+		);
+
+		// If there is an authorization token, append it to the request URI.
+		if ( $this->auth_token ) {
+			$request_uri = add_query_arg( 'access_token', $this->auth_token, $request_uri );
+		}
+
+		$response = wp_remote_get( esc_url_raw( $request_uri ) );
+
+		if ( ! $response ) {
+			return false;
+		}
+
+		// Get the response body and parse it.
+		$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( is_array( $api_response ) ) {
+			$api_response = current( $api_response );
+		}
+
+		// If there is an auth token, add it to the zip url.
+		if ( $this->auth_token ) {
+			$api_response['zipball_url'] = add_query_arg( 'access_token', $this->auth_token, $api_response['zipball_url'] );
+		}
+
+		return $api_response;
+	}
 
 	/**
-	 * update the transient etc
+	 * Checks for a newer version and updates the transient if so.
+	 *
+	 * Callback function for the WP API `{site_}transient_update_plugins`
+	 * filter hooks. Checks the version number from the installed version of the
+	 * plugin against the latest release on GitHub and pushes the result into
+	 * the WP plugin updates transient.
+	 *
+	 * @link https://codex.wordpress.org/Transients_API
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param object $transient Required. The WP update_plugins transient.
+	 * @return object $transient The same or modified transient object.
 	 */
-	public function modify_transient( $transient ) {
-		// check and update the transient
+	public function push_transient_update( $transient ) {
+		// Return early if WP is installing.
+		if ( wp_installing() ) {
+			return $transient;
+		}
+
+		// Return early if the WordPress hasn't checked for updates.
+		if ( empty( $transient->checked[ $this->basename ] ) ) {
+			return $transient;
+		}
+
+		// Try to get plugin details from the cache before checking the API.
+		if ( false === ( $this->github_response = get_transient( 'update_plugin_' . WSUWP_Help_Docs::$post_type_slug ) ) ) {
+			$this->github_response = $this->get_repository_details();
+
+echo '<script type="text/javascript">console.log("Step 1: No cached version found; ran a new request.")</script>'; // DEBUG: check if this fired
+
+			if ( ! is_wp_error( $this->github_response ) && ! empty( $this->github_response['zipball_url'] ) ) {
+				// Save results of a successful API call to a 12-hour transient cache.
+				set_transient( 'update_plugin_' . WSUWP_Help_Docs::$post_type_slug, $this->github_response, 43200 );
+
+				dbgx_trace_var( get_transient( 'update_plugin_' . WSUWP_Help_Docs::$post_type_slug ) ); // DEBUG:
+			}
+		}
+
+		// If have the plugin details, add them to the update_plugins transient.
+		if ( $this->github_response ) {
+
+			echo '<script type="text/javascript">console.log("Yes there is a response.")</script>'; // DEBUG: check if this fired
+			dbgx_trace_var( $this->basename ); // DEBUG: why are you missing?
+
+			// If GitHub version greater than installed version.
+			if ( true === version_compare( str_replace( 'v', '', $this->github_response['tag_name'] ), $transient->checked[ $this->basename ], 'gt' ) ) {
+
+				echo '<script type="text/javascript">console.log("Yes version compare was true.")</script>'; // DEBUG: check if this fired
+
+				$package = $this->github_response['zipball_url'];
+				$slug    = current( explode( '/', $this->basename ) );
+
+				$obj              = new stdClass();
+				$obj->slug        = $slug;
+				$obj->plugin      = $this->basename;
+				$obj->new_version = $this->github_response['tag_name'];
+				$obj->package     = $package;
+				$obj->url         = $this->plugin_meta["PluginURI"];
+
+				$transient->response[ $this->basename ] = $obj;
+			}
+
+			echo '<script type="text/javascript">console.log("Trigger 2")</script>'; // DEBUG: check if this fired
+			if ( isset( $obj ) ) {
+				dbgx_trace_var( $obj ); // DEBUG: check the response format
+			}
+			// $obj = stdClass::__set_state(array(
+			//    'slug' => '',
+			//    'plugin' => NULL,
+			//    'new_version' => 'v0.3.1',
+			//    'package' => 'https://api.github.com/repos/washingtonstateuniversity/WSUWP-Plugin-Help-Docs/zipball/v0.3.1',
+			//    'url' => NULL,
+			// ))
+		}
+
+		echo '<script type="text/javascript">console.log("Trigger 3")</script>'; // DEBUG: check if this fired
+		dbgx_trace_var( $transient ); // DEBUG: check the response format
+
+		return $transient;
 	}
 
 	/**
 	 * display the plugin details modal window
+	 *
+	 * retrieve and display the plugin release info as the details window.
 	 */
 	public function display_plugin_details( $result, $action, $args ) {
-		// retrieve and display the plugin release info as the details window.
+		// Do nothing if this isn't a request for information.
+		if ( 'plugin_information' !== $action ) {
+			return false;
+		}
+
+		// Return the result now if it isn't our plugin.
+		if ( current( explode( '/', $this->basename ) ) !== $args->slug ) {
+			return $result;
+		}
+
+		// Try to get plugin details from the cache before checking the API.
+		if ( false === ( $this->github_response = get_transient( 'update_plugin_' . WSUWP_Help_Docs::$post_type_slug ) ) ) {
+			$this->github_response = $this->get_repository_details();
+
+			if ( ! is_wp_error( $this->github_response ) && ! empty( $this->github_response['zipball_url'] ) ) {
+				// Save results of a successful API call to a 12-hour transient cache.
+				set_transient( 'update_plugin_' . WSUWP_Help_Docs::$post_type_slug, $this->github_response, 43200 );
+			}
+		}
+
+		if ( $this->github_response ) {
+
+			$result = new stdClass();
+			$result->name = $this->plugin_meta["Name"];
+			$result->slug = $this->basename;
+			$result->version = $this->github_response['tag_name'];
+			$result->requires = '3.3';
+			$result->tested = '4.9';
+			$result->rating = '100';
+			$result->num_ratings = '1';
+			$result->downloaded = '1';
+			$result->author = $this->plugin_meta["AuthorName"];
+			$result->author_profile = $this->plugin_meta["AuthorURI"];
+			$result->last_updated = $this->github_response['published_at'];
+			$result->homepage = $this->plugin_meta["PluginURI"];
+			$result->short_description = $this->plugin_meta["Description"];
+			$result->sections = array(
+				'description' => $this->plugin_meta["Description"],
+				'updates' => $this->github_response['body'],
+			);
+			$result->download_link = $this->github_response['zipball_url'];
+
+			return $result;
+		}
+
+		return false;
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-help-docs",
-  "version": "0.3.1",
+  "version": "0.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs"
@@ -36,6 +36,6 @@
     "build:css": "npm run lintscss -s && npm run sass -s",
     "test": "npm run phpcs -s && npm run lintscss -s",
     "prebuild": "npm run clean -s && npm run phpcs -s",
-    "build": "npm run build:css -s",
+    "build": "npm run build:css -s"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,5 @@
     "test": "npm run phpcs -s && npm run lintscss -s",
     "prebuild": "npm run clean -s && npm run phpcs -s",
     "build": "npm run build:css -s",
-    "deploy": "mkdirp build && cpx {*.php,*.css,README.md,LICENSE.txt,css/**,includes/**,templates/**} build"
   }
 }

--- a/src/scss/dashboard.scss
+++ b/src/scss/dashboard.scss
@@ -2,7 +2,7 @@
 Plugin Name: WSUWP Help Docs
 Author: Adam Turner, WSU University Communication
 Author URI: https://hrs.wsu.edu/
-Version: 0.3.1
+Version: 0.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/wsuwp-help-docs.php
+++ b/wsuwp-help-docs.php
@@ -1,13 +1,13 @@
 <?php
 /*
 Plugin Name: WSUWP Help Docs
-Version: 0.3.1
+Version: 0.4.1
 Description: A plugin to create Help documents for use in the Admin area.
 Author: Adam Turner, washingtonstateuniversity
 Author URI: https://github.com/washingtonstateuniversity/
 Plugin URI: https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs
 Text Domain: wsuwp-help-docs
-Requires at least: 3.3
+Requires at least: 3.5
 Tested up to: 4.9.9
 Requires PHP: 5.3
 */

--- a/wsuwp-help-docs.php
+++ b/wsuwp-help-docs.php
@@ -7,6 +7,9 @@ Author: Adam Turner, washingtonstateuniversity
 Author URI: https://github.com/washingtonstateuniversity/
 Plugin URI: https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs
 Text Domain: wsuwp-help-docs
+Requires at least: 3.3
+Tested up to: 4.9.9
+Requires PHP: 5.3
 */
 
 // If this file is called directly, abort.

--- a/wsuwp-help-docs.php
+++ b/wsuwp-help-docs.php
@@ -38,3 +38,31 @@ register_deactivation_hook( __FILE__, array( 'WSUWP_Help_Docs', 'deactivate' ) )
 function load_wsuwp_help() {
 	return WSUWP_Help_Docs::get_instance();
 }
+
+/**
+ * Creates an instance of the WSUWP Help Docs Updater class.
+ *
+ * This class handles updating the plugin from its GitHub repository. Update
+ * the GitHub username and repository name here to match the desired build
+ * source.
+ *
+ * @since 0.4.0
+ *
+ * @return object Instance of WSUWP_Help_Docs_Updater
+ */
+function load_wsuwp_help_updater() {
+	$updater = WSUWP_Help_Docs_Updater::get_instance( __FILE__ );
+
+	/*
+	 * Define the plugin repo GitHub credentials. Required properties include:
+	 * 'username' (the GitHub username) and 'repository' (the name of the repo).
+	 * For private repositories you must also include an auth token value for
+	 * the 'auth_token' property.
+	 */
+	$updater->set_github_credentials( array(
+		'username'   => 'admturner',
+		'repository' => 'WSUWP-Plugin-Help-Docs',
+	) );
+
+	return $updater;
+}

--- a/wsuwp-help-docs.php
+++ b/wsuwp-help-docs.php
@@ -60,7 +60,7 @@ function load_wsuwp_help_updater() {
 	 * the 'auth_token' property.
 	 */
 	$updater->set_github_credentials( array(
-		'username'   => 'admturner',
+		'username'   => 'washingtonstateuniversity',
 		'repository' => 'WSUWP-Plugin-Help-Docs',
 	) );
 


### PR DESCRIPTION
This release adds functionality to allow the Help Docs plugin to use the WordPress automatic updates feature. The new `WSUWP_Help_Docs_Updater` class hooks into WP's own update cron job and adds the WSUWP-Plugin-Help-Docs repo as a source for the plugin. The class will fetch the latest release (once every 12 hours or so) from GitHub and notify the user that an update is available if the latest release version is higher than the installed version.

Major features included in this release:

* Check GitHub release API for newer versions and cache results for 12 hours. (Also includes cached error handling to avoid overloading the GitHub API rate limit.)
* Provide a plugin details modal window that fetches plugin meta from GitHub and WP (using the main plugin file head matter), including minimum WP and PHP versions required.
* Guarantee plugin file updates overwrite the previous version.
* Add a `.gitattributes` file to help provide cleaner build versions by ignoring development files.