### PR TITLE
Clear updater transient on deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Changelog formatting (http://semver.org/):
 ### Removed (for deprecated features removed in this release)
 -->
 
+## 0.5.0 (2018-09-27)
+
+### Changed
+
+* The WSUWP_Help_Docs_Updater class $slug property is now public and static so that the flush transient method can run from outside the class.
+
+### Added
+
+* WSUWP_Help_Docs_Updater method to delete the `update_plugin_{slug}` transient so that it can be called from the plugin deactivation hook (allowing a method to force a check for new updates).
+
 ## 0.4.1 (2018-09-27)
 
 ### Fixed

--- a/includes/class-help-docs-setup.php
+++ b/includes/class-help-docs-setup.php
@@ -22,7 +22,7 @@ class WSUWP_Help_Docs {
 	 * @since 0.1.0
 	 * @var string
 	 */
-	protected $version = '0.3.1';
+	protected $version = '0.5.0';
 
 	/**
 	 * Slug used to register the post type.
@@ -132,9 +132,12 @@ class WSUWP_Help_Docs {
 	 * @since 0.1.0
 	 */
 	public static function deactivate() {
-		// Deregister custom post type, taxonomy, and shortcode (remove rules from memory).
+		// Deregister custom post type and shortcode (remove rules from memory).
 		unregister_post_type( self::$post_type_slug );
 		remove_shortcode( 'helplink' );
+
+		// Delete the update_plugin transient.
+		WSUWP_Help_Docs_Updater::flush_transient_cache();
 
 		// Flush rewrite rules on plugin deactivation to remove custom permalinks.
 		flush_rewrite_rules();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuwp-help-docs",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-help-docs"

--- a/src/scss/dashboard.scss
+++ b/src/scss/dashboard.scss
@@ -2,7 +2,7 @@
 Plugin Name: WSUWP Help Docs
 Author: Adam Turner, WSU University Communication
 Author URI: https://hrs.wsu.edu/
-Version: 0.4.1
+Version: 0.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/wsuwp-help-docs.php
+++ b/wsuwp-help-docs.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WSUWP Help Docs
-Version: 0.4.1
+Version: 0.5.0
 Description: A plugin to create Help documents for use in the Admin area.
 Author: Adam Turner, washingtonstateuniversity
 Author URI: https://github.com/washingtonstateuniversity/


### PR DESCRIPTION
Add a method to flush the `update_plugin_{slug}` transient on plugin deactivation so that when reactivated it will always check for a newer version. This is a cheaty way to force a check for updates, and just a nice way to clean up after ourselves. Since we cache everything for 1-12 hours (on errors and success, respectively) we don't really risk overloading the GitHub API or ourselves unless a users activates & deactivates the plugin once a minute for an hour.